### PR TITLE
feat: add structured error logging to Lambda MCP server functions

### DIFF
--- a/src/lambda/mcp_servers/athena/lambda_function.py
+++ b/src/lambda/mcp_servers/athena/lambda_function.py
@@ -57,7 +57,6 @@ import re
 import boto3
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 # Block DDL/DML operations - defense in depth (IAM also restricts write actions)
 BLOCKED_SQL_PATTERNS = re.compile(

--- a/src/lambda/mcp_servers/athena/lambda_function.py
+++ b/src/lambda/mcp_servers/athena/lambda_function.py
@@ -51,9 +51,13 @@ Required IAM Permissions:
 """
 
 import json
+import logging
 import re
 
 import boto3
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 # Block DDL/DML operations - defense in depth (IAM also restricts write actions)
 BLOCKED_SQL_PATTERNS = re.compile(
@@ -165,6 +169,7 @@ def handle_start_query_execution(event):
             "message": f"Query started. Use get_query_execution with query_execution_id '{query_execution_id}' to check status.",
         }
     except Exception as e:
+        logger.error("Error in handle_start_query_execution", exc_info=True)
         return {"error": str(e)}
 
 
@@ -220,6 +225,7 @@ def handle_get_query_execution(event):
 
         return result
     except Exception as e:
+        logger.error("Error in handle_get_query_execution", exc_info=True)
         return {"error": str(e), "query_execution_id": query_execution_id}
 
 
@@ -295,6 +301,7 @@ def handle_get_query_results(event):
             "next_token": response.get("NextToken"),
         }
     except Exception as e:
+        logger.error("Error in handle_get_query_results", exc_info=True)
         return {"error": str(e), "query_execution_id": query_execution_id}
 
 
@@ -353,6 +360,7 @@ def handle_list_query_executions(event):
             "next_token": response.get("NextToken"),
         }
     except Exception as e:
+        logger.error("Error in handle_list_query_executions", exc_info=True)
         return {"error": str(e)}
 
 
@@ -391,6 +399,7 @@ def handle_list_databases(event):
             "next_token": response.get("NextToken"),
         }
     except Exception as e:
+        logger.error("Error in handle_list_databases", exc_info=True)
         return {"error": str(e), "catalog": catalog}
 
 
@@ -443,6 +452,7 @@ def handle_list_tables(event):
             "next_token": response.get("NextToken"),
         }
     except Exception as e:
+        logger.error("Error in handle_list_tables", exc_info=True)
         return {"error": str(e), "database": database}
 
 
@@ -489,6 +499,7 @@ def handle_get_table_metadata(event):
             "create_time": str(table_meta.get("CreateTime", "")),
         }
     except Exception as e:
+        logger.error("Error in handle_get_table_metadata", exc_info=True)
         return {"error": str(e), "database": database, "table": table}
 
 
@@ -515,4 +526,5 @@ def handle_stop_query_execution(event):
             "message": "Query execution stop request submitted successfully",
         }
     except Exception as e:
+        logger.error("Error in handle_stop_query_execution", exc_info=True)
         return {"error": str(e), "query_execution_id": query_execution_id}

--- a/src/lambda/mcp_servers/cost_explorer/lambda_function.py
+++ b/src/lambda/mcp_servers/cost_explorer/lambda_function.py
@@ -43,10 +43,14 @@ Required IAM Permissions:
 """
 
 import json
+import logging
 import re
 from datetime import datetime, timedelta
 
 import boto3
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 # Valid Cost Explorer dimensions per AWS API
 VALID_DIMENSIONS = {
@@ -159,6 +163,7 @@ def handle_get_dimension_values(event):
             "count": len(values),
         }
     except Exception as e:
+        logger.error("Error in handle_get_dimension_values", exc_info=True)
         return {"error": str(e), "dimension": dimension}
 
 
@@ -190,6 +195,7 @@ def handle_get_tag_values(event):
             "count": len(values),
         }
     except Exception as e:
+        logger.error("Error in handle_get_tag_values", exc_info=True)
         return {"error": str(e), "tag_key": tag_key}
 
 
@@ -251,6 +257,7 @@ def handle_get_cost_and_usage(event):
             "results": results,
         }
     except Exception as e:
+        logger.error("Error in handle_get_cost_and_usage", exc_info=True)
         return {"error": str(e)}
 
 
@@ -337,6 +344,7 @@ def handle_get_cost_and_usage_comparisons(event):
             "total_previous": round(sum(previous_costs.values()), 2),
         }
     except Exception as e:
+        logger.error("Error in handle_get_cost_and_usage_comparisons", exc_info=True)
         return {"error": str(e)}
 
 
@@ -381,4 +389,5 @@ def handle_get_cost_forecast(event):
             ],
         }
     except Exception as e:
+        logger.error("Error in handle_get_cost_forecast", exc_info=True)
         return {"error": str(e)}

--- a/src/lambda/mcp_servers/cost_explorer/lambda_function.py
+++ b/src/lambda/mcp_servers/cost_explorer/lambda_function.py
@@ -50,7 +50,6 @@ from datetime import datetime, timedelta
 import boto3
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 # Valid Cost Explorer dimensions per AWS API
 VALID_DIMENSIONS = {

--- a/src/lambda/mcp_servers/cur_analyst/lambda_function.py
+++ b/src/lambda/mcp_servers/cur_analyst/lambda_function.py
@@ -31,11 +31,15 @@ Required IAM Permissions:
 """
 
 import json
+import logging
 import os
 import re
 import time
 
 import boto3
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 # Cross-account support - shared module is packaged alongside lambda_function.py
 try:
@@ -339,6 +343,7 @@ def collect_cost_explorer_data() -> dict:
             GroupBy=[{"Type": "DIMENSION", "Key": "LINKED_ACCOUNT"}],
         ).get("ResultsByTime", [])
     except Exception as e:
+        logger.error("Error in collect_cost_explorer_data: monthly_trend_by_account", exc_info=True)
         results["monthly_trend_by_account"] = {"error": str(e)}
 
     try:
@@ -350,6 +355,7 @@ def collect_cost_explorer_data() -> dict:
             GroupBy=[{"Type": "DIMENSION", "Key": "SERVICE"}],
         ).get("ResultsByTime", [])
     except Exception as e:
+        logger.error("Error in collect_cost_explorer_data: monthly_trend_by_service", exc_info=True)
         results["monthly_trend_by_service"] = {"error": str(e)}
 
     # === CURRENT MONTH BREAKDOWN ===
@@ -362,6 +368,7 @@ def collect_cost_explorer_data() -> dict:
             GroupBy=[{"Type": "DIMENSION", "Key": "LINKED_ACCOUNT"}],
         ).get("ResultsByTime", [])
     except Exception as e:
+        logger.error("Error in collect_cost_explorer_data: current_month_by_account", exc_info=True)
         results["current_month_by_account"] = {"error": str(e)}
 
     try:
@@ -373,6 +380,7 @@ def collect_cost_explorer_data() -> dict:
             GroupBy=[{"Type": "DIMENSION", "Key": "SERVICE"}, {"Type": "DIMENSION", "Key": "LINKED_ACCOUNT"}],
         ).get("ResultsByTime", [])
     except Exception as e:
+        logger.error("Error in collect_cost_explorer_data: current_month_by_service", exc_info=True)
         results["current_month_by_service"] = {"error": str(e)}
 
     try:
@@ -384,6 +392,7 @@ def collect_cost_explorer_data() -> dict:
             GroupBy=[{"Type": "DIMENSION", "Key": "REGION"}],
         ).get("ResultsByTime", [])
     except Exception as e:
+        logger.error("Error in collect_cost_explorer_data: current_month_by_region", exc_info=True)
         results["current_month_by_region"] = {"error": str(e)}
 
     return {
@@ -426,6 +435,7 @@ def collect_savings_and_forecast() -> dict:
             TimePeriod={"Start": six_months_ago, "End": end_date}, Granularity="MONTHLY"
         ).get("SavingsPlansCoverages", [])
     except Exception as e:
+        logger.error("Error in collect_savings_and_forecast: sp_coverage", exc_info=True)
         results["sp_coverage"] = {"error": str(e)}
 
     # 2. Savings Plans Utilization (6 months, monthly)
@@ -434,6 +444,7 @@ def collect_savings_and_forecast() -> dict:
             TimePeriod={"Start": six_months_ago, "End": end_date}, Granularity="MONTHLY"
         ).get("SavingsPlansUtilizationsByTime", [])
     except Exception as e:
+        logger.error("Error in collect_savings_and_forecast: sp_utilization", exc_info=True)
         results["sp_utilization"] = {"error": str(e)}
 
     # 3. Reserved Instance Coverage (6 months, monthly)
@@ -442,6 +453,7 @@ def collect_savings_and_forecast() -> dict:
             TimePeriod={"Start": six_months_ago, "End": end_date}, Granularity="MONTHLY"
         ).get("CoveragesByTime", [])
     except Exception as e:
+        logger.error("Error in collect_savings_and_forecast: ri_coverage", exc_info=True)
         results["ri_coverage"] = {"error": str(e)}
 
     # 4. Reserved Instance Utilization (6 months, monthly)
@@ -450,6 +462,7 @@ def collect_savings_and_forecast() -> dict:
             TimePeriod={"Start": six_months_ago, "End": end_date}, Granularity="MONTHLY"
         ).get("UtilizationsByTime", [])
     except Exception as e:
+        logger.error("Error in collect_savings_and_forecast: ri_utilization", exc_info=True)
         results["ri_utilization"] = {"error": str(e)}
 
     # 5. Cost Forecast (requires 14+ days history)
@@ -462,6 +475,7 @@ def collect_savings_and_forecast() -> dict:
         if "DataUnavailable" in error_msg or "BillEstimate" in error_msg:
             results["forecast"] = {"note": "insufficient history for forecast (requires 14+ days)"}
         else:
+            logger.error("Error in collect_savings_and_forecast: forecast", exc_info=True)
             results["forecast"] = {"error": error_msg}
 
     return {
@@ -547,6 +561,7 @@ def handle_analyze_cur(event):
         results["cost_explorer"] = ce_result.get("cost_explorer_data", {})
         results["cost_explorer_date_range"] = ce_result.get("date_range", {})
     except Exception as e:
+        logger.error("Error in handle_analyze_cur: cost_explorer", exc_info=True)
         results["errors"].append(f"cost_explorer: {e!s}")
         print(f"Cost Explorer error: {e}")
 
@@ -555,6 +570,7 @@ def handle_analyze_cur(event):
         savings_result = collect_savings_and_forecast()
         results["savings_forecast"] = savings_result.get("savings_data", {})
     except Exception as e:
+        logger.error("Error in handle_analyze_cur: savings_forecast", exc_info=True)
         results["errors"].append(f"savings_forecast: {e!s}")
         print(f"Savings/Forecast error: {e}")
 
@@ -572,6 +588,7 @@ def handle_analyze_cur(event):
         cur_results = retrieve_all_results(historical_ids, detailed_ids)
         results["cur_data"] = cur_results.get("results", {})
     except Exception as e:
+        logger.error("Error in handle_analyze_cur: cur_athena", exc_info=True)
         results["errors"].append(f"cur_athena: {e!s}")
         print(f"CUR Athena error: {e}")
 

--- a/src/lambda/mcp_servers/cur_analyst/lambda_function.py
+++ b/src/lambda/mcp_servers/cur_analyst/lambda_function.py
@@ -39,7 +39,6 @@ import time
 import boto3
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 # Cross-account support - shared module is packaged alongside lambda_function.py
 try:
@@ -473,6 +472,7 @@ def collect_savings_and_forecast() -> dict:
     except Exception as e:
         error_msg = str(e)
         if "DataUnavailable" in error_msg or "BillEstimate" in error_msg:
+            logger.info("Forecast data unavailable (expected): %s", error_msg)
             results["forecast"] = {"note": "insufficient history for forecast (requires 14+ days)"}
         else:
             logger.error("Error in collect_savings_and_forecast: forecast", exc_info=True)
@@ -563,7 +563,6 @@ def handle_analyze_cur(event):
     except Exception as e:
         logger.error("Error in handle_analyze_cur: cost_explorer", exc_info=True)
         results["errors"].append(f"cost_explorer: {e!s}")
-        print(f"Cost Explorer error: {e}")
 
     try:
         print("Phase 1b: Collecting Savings and Forecast data...")
@@ -572,7 +571,6 @@ def handle_analyze_cur(event):
     except Exception as e:
         logger.error("Error in handle_analyze_cur: savings_forecast", exc_info=True)
         results["errors"].append(f"savings_forecast: {e!s}")
-        print(f"Savings/Forecast error: {e}")
 
     # Phase 2: CUR Athena Queries
     try:
@@ -590,7 +588,6 @@ def handle_analyze_cur(event):
     except Exception as e:
         logger.error("Error in handle_analyze_cur: cur_athena", exc_info=True)
         results["errors"].append(f"cur_athena: {e!s}")
-        print(f"CUR Athena error: {e}")
 
     # Remove errors key if empty
     if not results["errors"]:


### PR DESCRIPTION
Add Python logging module with module-level logger to all three Lambda MCP server functions. Each except block now calls logger.error() with exc_info=True to emit full stack traces to CloudWatch Logs, while preserving the existing {"error": str(e)} return format for backward compatibility.

Closes #1

Generated with [Claude Code](https://claude.ai/code)