### PR TITLE
security: ISO 27001:2022 Annex A compliance remediations

### DIFF
--- a/src/lambda/proxy/lambda_function.py
+++ b/src/lambda/proxy/lambda_function.py
@@ -37,7 +37,8 @@ def invoke_mcp_runtime(mcp_request: dict) -> dict:
     payload = json.dumps(mcp_request).encode("utf-8")
 
     print(f"Invoking runtime: {RUNTIME_ARN}")
-    print(f"Payload: {mcp_request}")
+    # Log method and id only; omit params to avoid logging sensitive tool arguments (A.8.12)
+    print(f"MCP method: {mcp_request.get('method')}, id: {mcp_request.get('id')}")
 
     try:
         response = client.invoke_agent_runtime(
@@ -109,7 +110,8 @@ def detect_tool_from_args(args: dict) -> str:
 
 def lambda_handler(event, context):
     """Lambda handler for MCP proxy requests."""
-    print(f"Received event: {json.dumps(event)}")
+    # Log event keys only (not values) to avoid logging sensitive data (A.8.12)
+    print(f"Received event keys: {list(event.keys()) if isinstance(event, dict) else type(event).__name__}")
 
     # Extract request body
     if "body" in event:

--- a/terraform/config/terraform.tfvars.example
+++ b/terraform/config/terraform.tfvars.example
@@ -89,6 +89,11 @@ enable_vpc = true
 # If not set, AWS managed encryption is used
 # lambda_kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/your-key-id"
 
+# KMS key ARN for CloudWatch Log Group encryption (optional, recommended for production)
+# Applies to all Lambda log groups and VPC flow logs. Meets A.8.24 (Use of cryptography).
+# If not set, AWS managed encryption is used
+# log_group_kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/your-key-id"
+
 # -----------------------------------------------------------------------------
 # Optional Configuration
 # -----------------------------------------------------------------------------

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -39,6 +39,8 @@ module "vpc" {
   aws_region   = var.aws_region
   vpc_cidr     = var.vpc_cidr
 
+  log_group_kms_key_arn = var.log_group_kms_key_arn
+
   tags = local.common_tags
 }
 
@@ -74,6 +76,7 @@ module "lambda_proxy" {
   reserved_concurrent_executions = var.lambda_reserved_concurrent_executions
   log_retention_in_days          = var.log_retention_in_days
   lambda_kms_key_arn             = var.lambda_kms_key_arn
+  log_group_kms_key_arn          = var.log_group_kms_key_arn
 
   tags = local.common_tags
 
@@ -106,6 +109,7 @@ module "mcp_test" {
   reserved_concurrent_executions = var.lambda_reserved_concurrent_executions
   log_retention_in_days          = var.log_retention_in_days
   lambda_kms_key_arn             = var.lambda_kms_key_arn
+  log_group_kms_key_arn          = var.log_group_kms_key_arn
 
   tags = local.common_tags
 }
@@ -146,6 +150,7 @@ module "mcp_cost_explorer" {
   reserved_concurrent_executions = var.lambda_reserved_concurrent_executions
   log_retention_in_days          = var.log_retention_in_days
   lambda_kms_key_arn             = var.lambda_kms_key_arn
+  log_group_kms_key_arn          = var.log_group_kms_key_arn
 
   tags = local.common_tags
 }
@@ -221,6 +226,7 @@ module "mcp_athena" {
   reserved_concurrent_executions = var.lambda_reserved_concurrent_executions
   log_retention_in_days          = var.log_retention_in_days
   lambda_kms_key_arn             = var.lambda_kms_key_arn
+  log_group_kms_key_arn          = var.log_group_kms_key_arn
 
   tags = local.common_tags
 }
@@ -309,6 +315,7 @@ module "mcp_cur_analyst" {
   reserved_concurrent_executions = var.lambda_reserved_concurrent_executions
   log_retention_in_days          = var.log_retention_in_days
   lambda_kms_key_arn             = var.lambda_kms_key_arn
+  log_group_kms_key_arn          = var.log_group_kms_key_arn
 
   tags = local.common_tags
 }

--- a/terraform/management-account-role.tf
+++ b/terraform/management-account-role.tf
@@ -144,6 +144,10 @@ resource "aws_iam_role" "mcp_gateway_cross_account" {
   description        = "Allows MCP Gateway in data collection account to access Cost Explorer and CUR data"
   assume_role_policy = data.aws_iam_policy_document.cross_account_trust[0].json
 
+  lifecycle {
+    prevent_destroy = true
+  }
+
   tags = merge(local.common_tags, {
     Purpose = "mcp-gateway-cross-account"
   })

--- a/terraform/modules/lambda-proxy/main.tf
+++ b/terraform/modules/lambda-proxy/main.tf
@@ -31,6 +31,10 @@ resource "aws_cloudwatch_log_group" "lambda" {
   retention_in_days = var.log_retention_in_days
   kms_key_id        = var.log_group_kms_key_arn
 
+  lifecycle {
+    prevent_destroy = true
+  }
+
   tags = var.tags
 }
 

--- a/terraform/modules/mcp-lambda/main.tf
+++ b/terraform/modules/mcp-lambda/main.tf
@@ -190,6 +190,10 @@ resource "aws_cloudwatch_log_group" "lambda" {
   retention_in_days = var.log_retention_in_days
   kms_key_id        = var.log_group_kms_key_arn
 
+  lifecycle {
+    prevent_destroy = true
+  }
+
   tags = var.tags
 }
 

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -46,6 +46,10 @@ resource "aws_cloudwatch_log_group" "flow_log" {
   retention_in_days = var.flow_log_retention_in_days
   kms_key_id        = var.log_group_kms_key_arn
 
+  lifecycle {
+    prevent_destroy = true
+  }
+
   tags = var.tags
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -240,3 +240,9 @@ variable "lambda_kms_key_arn" {
   type        = string
   default     = null
 }
+
+variable "log_group_kms_key_arn" {
+  description = "ARN of KMS key to encrypt CloudWatch Log Groups (Lambda + VPC flow logs). If null, AWS managed encryption is used. Recommended for production deployments to meet A.8.24 (Use of cryptography)."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Applies ISO 27001:2022 Annex A compliance remediations identified in issue #7.

Changes:
- Add `log_group_kms_key_arn` to root module and wire through all submodules (A.8.24)
- Add `prevent_destroy` lifecycle to CloudWatch log groups (A.8.15)
- Add `prevent_destroy` lifecycle to management account IAM role (A.8.9)
- Sanitize proxy Lambda event logging (A.8.12/A.8.28)

Related compliance issues created: #9, #10, #11, #12, #13, #14

Closes #7

Generated with [Claude Code](https://claude.ai/code)